### PR TITLE
Fix API breakages from Rocket.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           override: true
           components: rustfmt, clippy
 

--- a/main/src/auth/login.rs
+++ b/main/src/auth/login.rs
@@ -149,7 +149,7 @@ pub async fn api_login(
 #[post("/login", data = "<data>")]
 pub async fn html_login(
     cookies: &CookieJar<'_>,
-    data: rocket::request::Form<LoginData>,
+    data: rocket::form::Form<LoginData>,
     conn: Database,
 ) -> Html {
     match login_base(cookies, &data, conn).await {

--- a/main/src/auth/register.rs
+++ b/main/src/auth/register.rs
@@ -222,7 +222,7 @@ pub async fn register_base(
 
 #[post("/register", data = "<data>")]
 pub async fn html_register(
-    data: rocket::request::Form<RegisterData>,
+    data: rocket::form::Form<RegisterData>,
     conn: Database,
     cookies: &CookieJar<'_>,
 ) -> Html {
@@ -319,7 +319,7 @@ pub async fn html_register(
 
 #[post("/register", data = "<data>")]
 pub async fn api_register(
-    data: rocket::request::Form<RegisterData>,
+    data: rocket::form::Form<RegisterData>,
     conn: Database,
     cookies: &CookieJar<'_>,
 ) -> Json<ApiResponse<User>> {

--- a/main/src/auth/verify.rs
+++ b/main/src/auth/verify.rs
@@ -1,6 +1,5 @@
 use diesel::prelude::*;
 use malvolio::prelude::*;
-use rocket::http::RawStr;
 
 use crate::{
     db::Database,
@@ -14,7 +13,7 @@ pub struct EmailVerificationToken {
 }
 
 #[get("/verify?<code>")]
-pub async fn verify_email(code: &RawStr, conn: Database) -> Html {
+pub async fn verify_email(code: &str, conn: Database) -> Html {
     use crate::schema::users::dsl as users;
     match jwt::decode::<EmailVerificationToken>(
         code,

--- a/main/src/calendar/connect/caldav.rs
+++ b/main/src/calendar/connect/caldav.rs
@@ -68,7 +68,7 @@ pub struct CaldavCalendarForm {
 #[post("/link", data = "<form>")]
 pub async fn connect_caldav_calendar(
     conn: Database,
-    form: rocket::request::Form<CaldavCalendarForm>,
+    form: rocket::form::Form<CaldavCalendarForm>,
     auth: AuthCookie,
 ) -> Html {
     use crate::schema::caldav;

--- a/main/src/calendar/connect/gcal.rs
+++ b/main/src/calendar/connect/gcal.rs
@@ -59,7 +59,7 @@ pub struct LinkCalendarForm {
 pub async fn link_calendar(
     auth: AuthCookie,
     oauth_state_values: State<'_, StateValues>,
-    form: rocket::request::Form<LinkCalendarForm>,
+    form: rocket::form::Form<LinkCalendarForm>,
 ) -> HtmlOrRedirect {
     let uuid = uuid::Uuid::new_v4().to_string();
 

--- a/main/src/calendar/connect/unauthenticated_caldav.rs
+++ b/main/src/calendar/connect/unauthenticated_caldav.rs
@@ -48,7 +48,7 @@ pub struct Unauthenticated {
 
 #[post("/link", data = "<form>")]
 pub async fn link_unauthenticated_caldav(
-    form: rocket::request::Form<Unauthenticated>,
+    form: rocket::form::Form<Unauthenticated>,
     auth: AuthCookie,
     conn: Database,
 ) -> Html {

--- a/main/src/class/create.rs
+++ b/main/src/class/create.rs
@@ -104,7 +104,7 @@ async fn create_class(
 
 #[post("/class/create", data = "<form>")]
 pub async fn html_create_class(
-    form: rocket::request::Form<CreateClassForm>,
+    form: rocket::form::Form<CreateClassForm>,
     auth: AuthCookie,
     conn: Database,
 ) -> Html {

--- a/main/src/class/delete.rs
+++ b/main/src/class/delete.rs
@@ -58,7 +58,7 @@ pub struct DeleteClassForm {
 
 #[post("/class/delete", data = "<form>")]
 pub async fn html_delete_class(
-    form: rocket::request::Form<DeleteClassForm>,
+    form: rocket::form::Form<DeleteClassForm>,
     auth_cookie: AuthCookie,
     conn: Database,
 ) -> Html {

--- a/main/src/class/invite.rs
+++ b/main/src/class/invite.rs
@@ -55,7 +55,7 @@ pub struct InviteTeacherForm {
 pub async fn html_invite_teacher(
     id: usize,
     auth_cookie: AuthCookie,
-    form: rocket::request::Form<InviteTeacherForm>,
+    form: rocket::form::Form<InviteTeacherForm>,
     conn: Database,
 ) -> Html {
     use crate::schema::class_teacher_invite::dsl as class_teacher_invite;
@@ -131,7 +131,7 @@ pub async fn html_invite_teacher(
 pub async fn api_invite_teacher(
     id: usize,
     auth_cookie: AuthCookie,
-    form: rocket::request::Form<InviteTeacherForm>,
+    form: rocket::form::Form<InviteTeacherForm>,
     conn: Database,
 ) -> Json<ApiResponse<()>> {
     use crate::schema::class_teacher_invite::dsl as class_teacher_invite;

--- a/main/src/class/messages/create/message.rs
+++ b/main/src/class/messages/create/message.rs
@@ -161,7 +161,7 @@ pub async fn html_apply_create_new_class_message(
     class_id: i32,
     auth: AuthCookie,
     conn: Database,
-    form: rocket::request::Form<CreateNewMessageForm>,
+    form: rocket::form::Form<CreateNewMessageForm>,
 ) -> HtmlOrRedirect {
     match create_new_class_message_base(class_id, auth, conn, &form).await {
         Ok(class_message) => HtmlOrRedirect::Redirect(Redirect::to(format!(

--- a/main/src/class/messages/create/reply.rs
+++ b/main/src/class/messages/create/reply.rs
@@ -74,7 +74,7 @@ pub async fn html_reply_to_teacher_message(
     message_id: i32,
     auth: AuthCookie,
     conn: Database,
-    form: rocket::request::Form<ReplyToTeacherMessageForm>,
+    form: rocket::form::Form<ReplyToTeacherMessageForm>,
 ) -> HtmlOrRedirect {
     match add_reply_to_teacher_message_base(class_id, message_id, auth, conn, &form).await {
         Ok(_) => HtmlOrRedirect::Redirect(Redirect::to(format!(
@@ -94,7 +94,7 @@ pub async fn api_reply_to_teacher_message(
     message_id: i32,
     auth: AuthCookie,
     conn: Database,
-    form: rocket::request::Form<ReplyToTeacherMessageForm>,
+    form: rocket::form::Form<ReplyToTeacherMessageForm>,
 ) -> Json<ApiResponse<ClassMessageReply>> {
     Json(
         match add_reply_to_teacher_message_base(class_id, message_id, auth, conn, &form).await {

--- a/main/src/class/messages/edit/message.rs
+++ b/main/src/class/messages/edit/message.rs
@@ -128,7 +128,7 @@ pub async fn api_apply_message_edit(
     message_id: i32,
     conn: Database,
     auth: AuthCookie,
-    form: rocket::request::Form<EditMessageForm>,
+    form: rocket::form::Form<EditMessageForm>,
 ) -> Json<ApiResponse<ClassMessage>> {
     Json(
         match apply_message_edit_base(message_id, conn, auth, &form).await {
@@ -146,7 +146,7 @@ pub async fn html_apply_message_edit(
     message_id: i32,
     conn: Database,
     auth: AuthCookie,
-    form: rocket::request::Form<EditMessageForm>,
+    form: rocket::form::Form<EditMessageForm>,
 ) -> HtmlOrRedirect {
     match apply_message_edit_base(message_id, conn, auth, &form).await {
         Ok(_) => HtmlOrRedirect::Redirect(Redirect::to(format!(

--- a/main/src/class/messages/edit/reply.rs
+++ b/main/src/class/messages/edit/reply.rs
@@ -118,7 +118,7 @@ pub async fn html_apply_message_reply_edit(
     message_id: i32,
     conn: Database,
     auth: AuthCookie,
-    form: rocket::request::Form<ApplyMessageReplyEditForm>,
+    form: rocket::form::Form<ApplyMessageReplyEditForm>,
 ) -> HtmlOrRedirect {
     match apply_message_reply_edit_base(class_id, message_reply_id, conn, auth, &form).await {
         Ok(_) => HtmlOrRedirect::Redirect(Redirect::to(format!(

--- a/main/src/class/tasks/asynchronous/create.rs
+++ b/main/src/class/tasks/asynchronous/create.rs
@@ -173,7 +173,7 @@ pub async fn html_create_new_async_task(
     conn: Database,
     class_id: i32,
     auth: AuthCookie,
-    form: rocket::request::Form<CreateNewAsyncTask>,
+    form: rocket::form::Form<CreateNewAsyncTask>,
 ) -> Html {
     match new_async_task(conn, class_id, auth, &form).await {
         Ok(_) => Html::new()

--- a/main/src/class/tasks/asynchronous/edit.rs
+++ b/main/src/class/tasks/asynchronous/edit.rs
@@ -166,7 +166,7 @@ pub async fn html_apply_edit_task(
     task_id: i32,
     auth: AuthCookie,
     conn: Database,
-    form: rocket::request::Form<EditTaskForm>,
+    form: rocket::form::Form<EditTaskForm>,
 ) -> Html {
     match apply_edit_task(class_id, task_id, auth, conn, &form).await {
         Ok(_) => Html::new()

--- a/main/src/class/tasks/synchronous/create.rs
+++ b/main/src/class/tasks/synchronous/create.rs
@@ -162,7 +162,7 @@ pub async fn html_create_new_sync_task(
     conn: Database,
     class_id: i32,
     auth: AuthCookie,
-    form: rocket::request::Form<CreateNewSyncTask>,
+    form: rocket::form::Form<CreateNewSyncTask>,
 ) -> Html {
     match create_new_sync_task(conn, class_id, auth, &form).await {
         Ok(_) => Html::new()

--- a/main/src/class/tasks/synchronous/edit.rs
+++ b/main/src/class/tasks/synchronous/edit.rs
@@ -183,7 +183,7 @@ pub async fn html_apply_edit_task(
     task_id: i32,
     auth: AuthCookie,
     conn: Database,
-    form: rocket::request::Form<EditTaskForm>,
+    form: rocket::form::Form<EditTaskForm>,
 ) -> Html {
     match apply_edit_task(class_id, task_id, auth, conn, &form).await {
         Ok(_) => Html::new()

--- a/main/src/institution/class/create.rs
+++ b/main/src/institution/class/create.rs
@@ -297,7 +297,7 @@ async fn apply_create_institution_class(
 pub async fn html_create_institution_class(
     conn: Database,
     auth: AuthCookie,
-    data: rocket::request::Form<CreateClassForm>,
+    data: rocket::form::Form<CreateClassForm>,
     institution_id: i32,
 ) -> HtmlOrRedirect {
     match apply_create_institution_class(conn, auth, &data, institution_id).await {

--- a/main/src/institution/configure.rs
+++ b/main/src/institution/configure.rs
@@ -159,7 +159,7 @@ pub async fn html_configure_institution(
     institution_id: i32,
     conn: Database,
     auth: AuthCookie,
-    form: rocket::request::Form<ConfigureInstitutionForm>,
+    form: rocket::form::Form<ConfigureInstitutionForm>,
 ) -> Html {
     match apply_configure_institution(conn, &form, auth, institution_id).await {
         Ok(institution) => Html::new()

--- a/main/src/institution/register.rs
+++ b/main/src/institution/register.rs
@@ -99,7 +99,7 @@ async fn register_new_institution(
 #[post("/register", data = "<form>")]
 pub async fn html_register_new_institution(
     auth: AuthCookie,
-    form: rocket::request::Form<CreateNewInstitutionForm>,
+    form: rocket::form::Form<CreateNewInstitutionForm>,
     conn: Database,
 ) -> Html {
     match register_new_institution(auth, conn, &form).await {


### PR DESCRIPTION
 - `rocket::request::Form` has moved into `rocket::form::Form`.

 - `RawStr` now does something quite different.